### PR TITLE
bump providers: azure, aws, openstack, cloudstack and uaa

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -13,8 +13,8 @@ ENV PROVIDER_CLOUDFOUNDRY_SUM baf908c3c8af4fcc06a772de45e61e2ebc5f3023939b58ddb4
 ENV PROVIDER_CREDHUB_VERSION 0.11.0
 ENV PROVIDER_CREDHUB_SUM 1b43ea2c404bb716eefa36e18a9fd8baa35f8e5ea991d98b2dd3447cba08435a
 
-ENV PROVIDER_UAA_VERSION 0.8.0
-ENV PROVIDER_UAA_SUM 2f8f2e6aa91c6f1b0c6d2064a0fd2cd7ca2b9d164211c87065b3ad8c9c344496
+ENV PROVIDER_UAA_VERSION 0.9.0
+ENV PROVIDER_UAA_SUM bfbab04dde59e70354c98f4516924c447d70c3bb3a5689dd4d6466e744162220
 
 RUN mkdir -p ${TERRAFORM_SHARED_DIR}
 
@@ -65,7 +65,7 @@ RUN set -ex \
     && export FILENAME="terraform-provider-uaa" \
     && export FILENAME_SUFFIX="_linux_amd64" \
     && export FULL_FILENAME="$FILENAME$FILENAME_SUFFIX" \
-    && export URL="https://github.com/mevansam/terraform-provider-uaa/releases/download/${PROVIDER_UAA_VERSION}/${FULL_FILENAME}" \
+    && export URL="https://github.com/orange-cloudfoundry/terraform-provider-uaa/releases/download/${PROVIDER_UAA_VERSION}/${FULL_FILENAME}" \
     && export SUM=${PROVIDER_UAA_SUM} \
     && wget ${URL} -O /tmp/${FULL_FILENAME} \
     && echo "Computed sha256sum: $(sha256sum /tmp/${FULL_FILENAME})" \

--- a/terraform/plugin_cache.tf
+++ b/terraform/plugin_cache.tf
@@ -1,5 +1,8 @@
 provider "aws" {
-  version = "1.6.0"
+  version = "1.26.0"
+}
+provider "azurerm" {
+  version = "1.8.0"
 }
 provider "template" {
   version = "1.0.0"
@@ -8,7 +11,7 @@ provider "null" {
   version = "1.0.0"
 }
 provider "openstack" {
-  version = "~> 1.4.0"
+  version = "~> 1.6.0"
 }
 provider "cloudflare" {
   version = "~> 1.0.0"
@@ -20,7 +23,7 @@ provider "powerdns" {
   version = "~> 0.1.0"
 }
 provider "cloudstack" {
-  version = "~> 0.1.4"
+  version = "~> 0.1.5"
 }
 provider "gitlab" {
   version = "~> 1.0.0"
@@ -48,5 +51,5 @@ provider "cloudfoundry" {
 
 # Community provider
 provider "uaa" {
-  version = "~> 0.8.0"
+  version = "~> 0.9.0"
 }

--- a/terraform/terraform_spec.rb
+++ b/terraform/terraform_spec.rb
@@ -58,7 +58,7 @@ describe "Terraform image" do
     end
 
     it "has the openstack provider" do
-      expect(@terraform_version_output).to include("provider.openstack v1.4.0")
+      expect(@terraform_version_output).to include("provider.openstack v1.6.0")
     end
 
     it "has the cloudstack provider" do
@@ -82,7 +82,7 @@ describe "Terraform image" do
     end
 
     it "has the uaa provider" do
-      expect(@terraform_version_output).to include("provider.uaa v0.8")
+      expect(@terraform_version_output).to include("provider.uaa v0.9")
     end
 
     it "has the flexibleengine provider" do
@@ -90,10 +90,8 @@ describe "Terraform image" do
     end
 
     it "has enough providers" do
-      EXPECTED_PROVIDER_COUNT = 16
+      EXPECTED_PROVIDER_COUNT = 17
       expect(@terraform_version_output.scan('provider.').length).to eq(EXPECTED_PROVIDER_COUNT)
     end
-
   end
-
 end


### PR DESCRIPTION
We add azure provider and switch to orange release for uaa provider.

Required by:
 - https://github.com/orange-cloudfoundry/cf-ops-automation/issues/120
 - https://github.com/orange-cloudfoundry/cf-ops-automation/issues/153