### PR TITLE
bump clis

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,7 +9,9 @@ on:
 
 env:
   DOCKERHUB_ORG: orangecloudfoundry
-  IMAGES: k8s-tools terraform bosh-cli-v2 bosh-cli-v2-cf-cli spruce spiff awscli cf-cli curl-ssl git-ssh
+  BASE_IMAGES: cf-cli curl-ssl git-ssh k8s-tools terraform bosh-cli-v2 spruce spiff
+  IMAGES_WITH_DEPENDENCIES: awscli bosh-cli-v2-cf-cli
+
 jobs:
   build_and_publish:
     name: build, test and publish
@@ -37,7 +39,7 @@ jobs:
     - 
       name: build docker images
       run: |
-        for image in $IMAGES;do
+        for image in $BASE_IMAGES;do
           echo "Processing $image"
           bundle exec rake build:$image
         done
@@ -45,11 +47,49 @@ jobs:
     -
       name: test docker images
       run: |
-        for image in $IMAGES;do
+        for image in $BASE_IMAGES;do
           echo "Processing $image"
           bundle exec rake spec:$image
         done
-
+    -
+      name: publish curl-ssl image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: curl-ssl
+    -
+      name: publish git-ssh image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: git-ssh
+    -
+      name: publish cf-cli image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: cf-cli
     -
       name: publish k8s-tools image
       uses: docker/build-push-action@v2
@@ -62,21 +102,7 @@ jobs:
           ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
           ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
-        IMAGE: k8s-tools          
-
-    -
-      name: publish bosh-cli-v2-cf-cli image
-      uses: docker/build-push-action@v2
-      with:
-        context: ${{env.IMAGE}}
-        push: true
-        tags: |
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
-      env:
-        IMAGE: bosh-cli-v2-cf-cli
+        IMAGE: k8s-tools
     -
       name: publish bosh-cli-v2 image
       uses: docker/build-push-action@v2
@@ -130,7 +156,21 @@ jobs:
           ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: spruce
+    -
+      name: build docker images with dependencies
+      run: |
+        for image in $IMAGES_WITH_DEPENDENCIES;do
+          echo "Processing $image"
+          bundle exec rake build:$image
+        done
 
+    -
+      name: test docker images with dependencies
+      run: |
+        for image in $IMAGES_WITH_DEPENDENCIES;do
+          echo "Processing $image"
+          bundle exec rake spec:$image
+        done
     -
       name: publish awscli image
       uses: docker/build-push-action@v2
@@ -145,7 +185,7 @@ jobs:
       env:
         IMAGE: awscli
     -
-      name: publish cf-cli image
+      name: publish bosh-cli-v2-cf-cli image
       uses: docker/build-push-action@v2
       with:
         context: ${{env.IMAGE}}
@@ -156,33 +196,7 @@ jobs:
           ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
           ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
-        IMAGE: cf-cli
-    -
-      name: publish curl-ssl image
-      uses: docker/build-push-action@v2
-      with:
-        context: ${{env.IMAGE}}
-        push: true
-        tags: |
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
-      env:
-        IMAGE: curl-ssl
-    -
-      name: publish git-ssh image
-      uses: docker/build-push-action@v2
-      with:
-        context: ${{env.IMAGE}}
-        push: true
-        tags: |
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
-          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
-      env:
-        IMAGE: git-ssh
+        IMAGE: bosh-cli-v2-cf-cli
 
 
   check_published_images:
@@ -192,7 +206,7 @@ jobs:
     steps:
       - name: check docker public images
         run: |
-          for image in $IMAGES;do
+          for image in $BASE_IMAGES $IMAGES_WITH_DEPENDENCIES;do
             echo "Processing $image"
             docker manifest inspect orangecloudfoundry/$image:$GITHUB_SHA
           done

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,4 +1,4 @@
-FROM governmentpaas/curl-ssl
+FROM orangecloudfoundry/curl-ssl
 
 ENV AWSCLI_VERSION "1.18.140"
 ENV PACKAGES "groff less python3 py-pip jq"

--- a/bosh-cli-v2-cf-cli/Dockerfile
+++ b/bosh-cli-v2-cf-cli/Dockerfile
@@ -2,8 +2,8 @@ FROM governmentpaas/bosh-cli-v2:latest
 
 # we use libc6 instead of libc6-compat as we do not use alpine base image
 ENV CF_PACKAGES "unzip curl openssl ca-certificates git libc6 bash jq gettext make"
-ENV CF_CLI_VERSION "7.2.0"
-ENV SPRUCE_VERSION "1.27.0"
+ENV CF_CLI_VERSION "7.4.0"
+ENV SPRUCE_VERSION "1.29.0"
 
 # we also use apt-get as we use an Ubuntu image, not an Alpine
 RUN apt-get update \

--- a/bosh-cli-v2-cf-cli/Dockerfile
+++ b/bosh-cli-v2-cf-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM governmentpaas/bosh-cli-v2:latest
+FROM orangecloudfoundry/bosh-cli-v2:latest
 
 # we use libc6 instead of libc6-compat as we do not use alpine base image
 ENV CF_PACKAGES "unzip curl openssl ca-certificates git libc6 bash jq gettext make"

--- a/bosh-cli-v2-cf-cli/bosh-cli-v2-cf-cli_spec.rb
+++ b/bosh-cli-v2-cf-cli/bosh-cli-v2-cf-cli_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.4-3c1a893c-2021-06-11T20:26:27Z"
-CREDHUB_VERSION='2.9.0'
-CF_CLI_VERSION="7.2.0"
+BOSH_CLI_VERSION="6.4.11-e5579de9-2022-01-05T23:48:09Z"
+CREDHUB_VERSION='2.9.1'
+CF_CLI_VERSION="7.4.0"
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.27.0"
+SPRUCE_VERSION = "1.29.0"
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"
 CF_ENV_DEPS = "unzip curl openssl ca-certificates git libc6 bash jq gettext make"

--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-slim-buster
 
-ENV BOSH_CLI_VERSION 6.4.7
-ENV BOSH_CLI_SUM 596abc123ddb676f081d375dc4672359fb1573c38d8dd3e8bdc4f3d2769783a1
+ENV BOSH_CLI_VERSION 6.4.11
+ENV BOSH_CLI_SUM ea3960f25c561346ab073c3d2133b9e5d35a62f1cd39cdcb986bff45c0ab0536
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
@@ -24,9 +24,6 @@ RUN wget -nv https://s3.amazonaws.com/bosh-cli-artifacts/${BOSH_CLI_FILENAME} \
   && chmod +x ${BOSH_CLI_FILENAME} \
   && mv ${BOSH_CLI_FILENAME} /usr/local/bin/bosh
 
-COPY bosh_init_cache /tmp/bosh_init_cache/
-RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
-    rm -rf /tmp/bosh_init_cache
 
 ENV CREDHUB_CLI_VERSION 2.9.1
 ENV CREDHUB_CLI_SUM df8aa256d4563d741bda71e4e0baff077addce8438dba4f9157504b387b93d9f

--- a/bosh-cli-v2/Dockerfile
+++ b/bosh-cli-v2/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.7-slim-buster
 
-ENV BOSH_CLI_VERSION 6.4.4
-ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb
+ENV BOSH_CLI_VERSION 6.4.7
+ENV BOSH_CLI_SUM 596abc123ddb676f081d375dc4672359fb1573c38d8dd3e8bdc4f3d2769783a1
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 
 ENV DEBIAN_PACKAGES "ca-certificates wget git openssh-client file jq"
@@ -28,8 +28,8 @@ COPY bosh_init_cache /tmp/bosh_init_cache/
 RUN /tmp/bosh_init_cache/seed_bosh_init_cache.sh && \
     rm -rf /tmp/bosh_init_cache
 
-ENV CREDHUB_CLI_VERSION 2.9.0
-ENV CREDHUB_CLI_SUM f260e926099f9eb9474ab2239851e391bfd0fd1354a52891f3c834cea1630e8a
+ENV CREDHUB_CLI_VERSION 2.9.1
+ENV CREDHUB_CLI_SUM df8aa256d4563d741bda71e4e0baff077addce8438dba4f9157504b387b93d9f
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 
 RUN wget -nv https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} \

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.7-44aadb4f-2021-09-17T18:39:29Z"
+BOSH_CLI_VERSION="6.4.11-e5579de9-2022-01-05T23:48:09Z"
 CREDHUB_VERSION='2.9.1'
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
@@ -88,18 +88,9 @@ describe "bosh-cli-v2 image" do
     expect(cmd.stdout).to match(/^ruby 2.7/)
   end
 
-  it "contains the compiled CPI packages" do
+  it "does not contain the compiled CPI packages" do
     installation_path = '/root/.bosh/installations/44f01911-a47a-4a24-6ca3-a3109b33f058'
     packages_file = file("#{installation_path}/compiled_packages.json")
-    expect(packages_file).to exist
-    compiled_packages = JSON.parse(packages_file.content)
-    compiled_packages.each do |package|
-      expect(file("#{installation_path}/blobs/#{package["Value"]["BlobID"]}")).to exist
-    end
-
-    cpi_package = compiled_packages.find {|p| p["Key"]["PackageName"] == "bosh_aws_cpi" }
-    expect(cpi_package).to be
-
-    expect(file("#{installation_path}/packages/bosh_aws_cpi/bin/aws_cpi")).to be_executable
+    expect(packages_file).not_to exist
   end
 end

--- a/bosh-cli-v2/bosh-cli_spec.rb
+++ b/bosh-cli-v2/bosh-cli_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.4-3c1a893c-2021-06-11T20:26:27Z"
-CREDHUB_VERSION='2.9.0'
+BOSH_CLI_VERSION="6.4.7-44aadb4f-2021-09-17T18:39:29Z"
+CREDHUB_VERSION='2.9.1'
 
 BOSH_ENV_DEPS = "build-essential zlibc zlib1g-dev openssl libxslt1-dev libxml2-dev \
     libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3"

--- a/cf-cli/Dockerfile
+++ b/cf-cli/Dockerfile
@@ -1,8 +1,8 @@
 FROM ruby:2.7-alpine3.11
 
 ENV PACKAGES "unzip curl openssl ca-certificates git libc6-compat bash jq gettext make"
-ENV CF_CLI_VERSION "7.2.0"
-ENV SPRUCE_VERSION "1.27.0"
+ENV CF_CLI_VERSION "7.3.0"
+ENV SPRUCE_VERSION "1.29.0"
 
 RUN apk add --no-cache $PACKAGES
 

--- a/cf-cli/cf-cli_spec.rb
+++ b/cf-cli/cf-cli_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-CF_CLI_VERSION="7.2.0"
+CF_CLI_VERSION="7.3.0"
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.27.0"
+SPRUCE_VERSION = "1.29.0"
 
 describe "cf-cli image" do
   before(:all) {

--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -62,7 +62,7 @@ RUN echo "Computed sha256sum: $(sha256sum ${HELM_FILENAME})" \
     && rm -rf linux-amd64
 
 ENV KUTTL_VERSION 0.11.1
-ENV KUTTL_PLUGIN_SUM ce481fed5af651893c431e8182d0a6a0350882c3ca4fa62e5ce0e3de876e9267
+ENV KUTTL_PLUGIN_SUM 0fb13f8fbb6109803a06847a8ad3fae4fedc8cd159e2b0fd6c1a1d8737191e5f
 ENV KUTTL_PLUGIN_FILENAME kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64
 ADD https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/${KUTTL_PLUGIN_FILENAME} .
 RUN echo "Computed ${KUTTL_PLUGIN_FILENAME} sha256sum: $(sha256sum ${KUTTL_PLUGIN_FILENAME})" \

--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -20,8 +20,8 @@ RUN echo "Computed sha256sum: $(sha256sum ${YTT_FILENAME})" \
     && mv ${YTT_FILENAME} ytt
 
 
-ENV CREDHUB_CLI_VERSION 2.9.0
-ENV CREDHUB_CLI_SUM f260e926099f9eb9474ab2239851e391bfd0fd1354a52891f3c834cea1630e8a
+ENV CREDHUB_CLI_VERSION 2.9.1
+ENV CREDHUB_CLI_SUM df8aa256d4563d741bda71e4e0baff077addce8438dba4f9157504b387b93d9f
 ENV CREDHUB_CLI_FILENAME credhub-linux-${CREDHUB_CLI_VERSION}.tgz
 ADD https://github.com/cloudfoundry-incubator/credhub-cli/releases/download/${CREDHUB_CLI_VERSION}/${CREDHUB_CLI_FILENAME} .
 RUN echo "Computed sha256sum: $(sha256sum ${CREDHUB_CLI_FILENAME})" \
@@ -48,7 +48,6 @@ ENV KUBECTL_VERSION 1.20.9
 ENV KUBECTL_SUM 9d76c4431e10e268dd7c6b53b27aaa62a6f26455013e1d7f6d85da86003539b9
 ENV KUBECTL_FILENAME kubectl
 ADD https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl .
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.20.9/bin/linux/amd64/kubectl .
 RUN echo "Computed sha256sum: $(sha256sum ${KUBECTL_FILENAME})" \
     && echo "${KUBECTL_SUM}  ${KUBECTL_FILENAME}" | sha256sum -c -
 
@@ -62,7 +61,7 @@ RUN echo "Computed sha256sum: $(sha256sum ${HELM_FILENAME})" \
     && mv linux-amd64/helm helm \
     && rm -rf linux-amd64
 
-ENV KUTTL_VERSION 0.11.0
+ENV KUTTL_VERSION 0.11.1
 ENV KUTTL_PLUGIN_SUM ce481fed5af651893c431e8182d0a6a0350882c3ca4fa62e5ce0e3de876e9267
 ENV KUTTL_PLUGIN_FILENAME kubectl-kuttl_${KUTTL_VERSION}_linux_x86_64
 ADD https://github.com/kudobuilder/kuttl/releases/download/v${KUTTL_VERSION}/${KUTTL_PLUGIN_FILENAME} .
@@ -79,8 +78,8 @@ RUN echo "${YQ_SUM}  ${YQ_FILENAME}" | sha256sum -c - \
     && chmod +x ${YQ_FILENAME} \
     && mv ${YQ_FILENAME} /usr/local/bin/yq
 
-ENV BOSH_CLI_VERSION 6.4.4
-ENV BOSH_CLI_SUM c944dd694e5470686995c2365ac60c9ef06f655cab51994f7fefed4c89e764fb
+ENV BOSH_CLI_VERSION 6.4.11
+ENV BOSH_CLI_SUM ea3960f25c561346ab073c3d2133b9e5d35a62f1cd39cdcb986bff45c0ab0536
 ENV BOSH_CLI_FILENAME bosh-cli-${BOSH_CLI_VERSION}-linux-amd64
 ADD https://s3.amazonaws.com/bosh-cli-artifacts/${BOSH_CLI_FILENAME} .
 RUN echo "${BOSH_CLI_SUM}  ${BOSH_CLI_FILENAME}" | sha256sum -c - \

--- a/k8s-tools/k8s-tools_spec.rb
+++ b/k8s-tools/k8s-tools_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 require 'docker'
 require 'serverspec'
 
-BOSH_CLI_VERSION="6.4.4-3c1a893c-2021-06-11T20:26:27Z"
+BOSH_CLI_VERSION="6.4.11-e5579de9-2022-01-05T23:48:09Z"
 YTT_VERSION="0.35.1"
-CREDHUB_VERSION='2.9.0'
+CREDHUB_VERSION='2.9.1'
 KUSTOMIZE_VERSION="4.2.0"
 KAPP_VERSION="0.37.0"
 KUBECTL_VERSION="1.20.9"
 HELM_VERSION="3.6.3"
-KUTTL_VERSION="0.11.0"
+KUTTL_VERSION="0.11.1"
 
 DEPS = "unzip curl openssl ca-certificates git libc6 bash jq gettext"
 

--- a/spruce/Dockerfile
+++ b/spruce/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13
 
-ENV SPRUCE_VERSION 1.27.0
+ENV SPRUCE_VERSION 1.29.0
 
 RUN apk add --no-cache wget ca-certificates \
   && wget https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \

--- a/spruce/spruce_spec.rb
+++ b/spruce/spruce_spec.rb
@@ -3,7 +3,7 @@ require 'docker'
 require 'serverspec'
 
 SPRUCE_BIN = "/usr/local/bin/spruce"
-SPRUCE_VERSION = "1.27.0"
+SPRUCE_VERSION = "1.29.0"
 ALPINE_VERSION = "3.13"
 
 describe "spruce image" do


### PR DESCRIPTION
- bosh cli: [6.4.11](https://github.com/cloudfoundry/bosh-cli/releases/tag/v6.4.11)
- cf cli: [7.4.0](https://github.com/cloudfoundry/cli/releases/tag/v7.4.0). (This include version [7.3.0](https://github.com/cloudfoundry/cli/releases/tag/v7.3.0) with [SAN required])
- credhub cli: [2.9.1](https://github.com/cloudfoundry/credhub-cli/releases/tag/2.9.1)
- spruce: [1.29](https://github.com/geofffranks/spruce/releases/tag/v1.29.0)

[SAN required]: https://github.com/cloudfoundry/routing-release/blob/develop/docs/golang1.15-remove-x509ignoreCN%3D0-flag-certificates-now-require-SANs.md