### PR TITLE
chore(build): build and publish images

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,8 +59,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
-        #ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: k8s-tools          
 
@@ -73,8 +73,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: bosh-cli-v2-cf-cli
     -
@@ -86,8 +86,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: bosh-cli-v2
     -
@@ -99,8 +99,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: terraform
  
@@ -113,8 +113,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: spiff
     -
@@ -126,8 +126,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: spruce
 
@@ -140,8 +140,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: awscli
     -
@@ -153,8 +153,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: cf-cli
     -
@@ -166,8 +166,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: curl-ssl
     -
@@ -179,8 +179,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+          ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: git-ssh
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,8 +9,7 @@ on:
 
 env:
   DOCKERHUB_ORG: orangecloudfoundry
-  IMAGES: k8s-tools terraform bosh-cli-v2 bosh-cli-v2-cf-cli spruce spiff
-
+  IMAGES: k8s-tools terraform bosh-cli-v2 bosh-cli-v2-cf-cli spruce spiff awscli cf-cli curl-ssl git-ssh
 jobs:
   build_and_publish:
     name: build, test and publish
@@ -60,8 +59,8 @@ jobs:
         tags: |
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
           ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
-        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+        #ghcr.io/${{ github.repository }}/${{env.IMAGE}}:latest
+        #ghcr.io/${{ github.repository }}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: k8s-tools          
 
@@ -131,6 +130,60 @@ jobs:
         #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
       env:
         IMAGE: spruce
+
+    -
+      name: publish awscli image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: awscli
+    -
+      name: publish cf-cli image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: cf-cli
+    -
+      name: publish curl-ssl image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: curl-ssl
+    -
+      name: publish git-ssh image
+      uses: docker/build-push-action@v2
+      with:
+        context: ${{env.IMAGE}}
+        push: true
+        tags: |
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+          ${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:latest
+        #ghcr.io/${{env.DOCKERHUB_ORG}}/${{env.IMAGE}}:${{github.sha}}
+      env:
+        IMAGE: git-ssh
+
 
   check_published_images:
     name: check published images


### PR DESCRIPTION
Changed proposed:
 - build all images used by cf-ops-automation
 - publish docker images also to ghcr
