### PR TITLE
bosh-cli-v2-cf-cli: add zip, scp and host

### DIFF
--- a/bosh-cli-v2-cf-cli/Dockerfile
+++ b/bosh-cli-v2-cf-cli/Dockerfile
@@ -2,6 +2,8 @@ FROM elpaasoci/bosh-cli-v2:latest
 
 # we use libc6 instead of libc6-compat as we do not use alpine base image
 ENV CF_PACKAGES "unzip curl openssl ca-certificates git libc6 bash jq gettext make"
+# dedicated packages required by osb-cmdb or kubectl/svcat tests
+ENV PAAS_TEMPLATES_PACKAGES "zip bind9-host openssh-client"
 # renovate: datasource=github-releases depName=cloudfoundry/cli
 ENV CF_CLI_VERSION "8.9.0"
 # renovate: datasource=github-releases depName=geofffranks/spruce
@@ -10,13 +12,13 @@ ENV SPRUCE_VERSION "1.31.1"
 # we also use apt-get as we use an Ubuntu image, not an Alpine
 RUN apt-get update \
   && apt-get -y upgrade \
-  && apt-get install -y --no-install-recommends ${CF_PACKAGES} \
+  && apt-get install -y --no-install-recommends ${CF_PACKAGES} ${PAAS_TEMPLATES_PACKAGES} \
   && rm -rf /var/lib/apt/lists/*
 
 RUN rm -rf ~/.bosh/cache  # Cleanup AWS CPI
 
-RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
+RUN curl -sSL "https://cli.run.pivotal.io/stable?release=linux64-binary&version=${CF_CLI_VERSION}" | tar -zx -C /usr/local/bin
 
-RUN curl -Lo /usr/local/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
+RUN curl -sSLo /usr/local/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
   && chmod +x /usr/local/bin/spruce
 

--- a/bosh-cli-v2-cf-cli/bosh-cli-v2-cf-cli_spec.rb
+++ b/bosh-cli-v2-cf-cli/bosh-cli-v2-cf-cli_spec.rb
@@ -115,4 +115,22 @@ describe "bosh-cli-v2-cf-cli image" do
       command("jq --help").exit_status
     ).to eq(0)
   end
+
+  it "has `host` available" do
+    expect(
+      command("host -V").exit_status
+    ).to eq(0)
+  end
+
+  it "has `zip` available" do
+    expect(
+      command("zip --version").exit_status
+    ).to eq(0)
+  end
+
+  it "has `scp` provided by `ssh` available" do
+    expect(
+      command("ssh -V").exit_status
+    ).to eq(0)
+  end
 end


### PR DESCRIPTION
## What

Include binaries reuired by [Missing aws-served bosh cli binaries supporting osb smoke tests and coab model post deploy: missing zip command in bosh-cli-v2-cf-cli container image](https://github.com/orange-cloudfoundry/paas-templates/issues/2487)

